### PR TITLE
Increase smoothness of write/validation progress information

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -351,7 +351,7 @@ rules:
     - error
   no-underscore-dangle:
     - error
-    - allowAfterThis: false
+    - allowAfterThis: true
   no-unneeded-ternary:
     - error
   no-whitespace-before-property:

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,12 +23,12 @@
 const Bluebird = require('bluebird');
 const EventEmitter = require('events').EventEmitter;
 const fs = Bluebird.promisifyAll(require('fs'));
-const progressStream = require('progress-stream');
 const streamChunker = require('stream-chunker');
 const OffsetWriteStream = require('./offset-write-stream');
 const offsetTransformStream = require('./offset-transform-stream');
 const bmapFile = require('./bmap-file');
 const hash = require('./hash');
+const Progress = require('./progress');
 
 /**
  * @summary Flash image to file descriptor
@@ -89,9 +89,11 @@ exports.flashImageToFileDescriptor = (imageStream, deviceFileDescriptor, bmapCon
       throw new Error(`Unsupported bmap version: ${bmap.version}`);
     }
 
-    const progress = progressStream({
+    const progress = new Progress({
       length: bmap.mappedBlocksCount * bmap.blockSize,
-      drain: true
+      callback: (state) => {
+        emitter.emit('progress', state);
+      }
     });
 
     return new Bluebird((resolve, reject) => {
@@ -105,16 +107,19 @@ exports.flashImageToFileDescriptor = (imageStream, deviceFileDescriptor, bmapCon
         .on('error', reject)
         .pipe(new OffsetWriteStream({
           write: (data, offset, callback) => {
-            progress.write(data, () => {
-              emitter.emit('progress', progress.progress());
-            });
+            fs.write(deviceFileDescriptor, data, 0, data.length, offset, (error) => {
+              if (error) {
+                return callback(error);
+              }
 
-            fs.write(deviceFileDescriptor, data, 0, data.length, offset, callback);
+              progress.tick(data);
+              return callback();
+            });
           }
         }))
         .on('error', reject)
         .on('finish', () => {
-          progress.end();
+          progress.stop();
           resolve();
         });
     });
@@ -194,36 +199,42 @@ exports.validateFlashedImage = (deviceFileDescriptor, bmapContents) => {
       throw new Error(`Unsupported bmap version: ${bmap.version}`);
     }
 
-    // We make use of `progress-stream` directly to benefit from
-    // the accurate and detailed progress information it reports,
-    // even though we're not using streams in this function.
-    const progress = progressStream({
+    const progress = new Progress({
       length: bmap.mappedBlocksCount * bmap.blockSize,
-      drain: true
+      callback: (state) => {
+        emitter.emit('progress', state);
+      }
     });
 
     return Bluebird.each(bmap.ranges, (range) => {
-      const length = (range.to - range.from + 1) * bmap.blockSize;
-      const data = Buffer.alloc(length);
       const position = range.from * bmap.blockSize;
+      const length = (range.to - range.from + 1) * bmap.blockSize;
+      const data = [];
 
-      return fs.readAsync(deviceFileDescriptor, data, 0, length, position).then((bytesRead) => {
-        if (bytesRead !== length) {
-          throw new Error(`Expected ${length} bytes but got ${bytesRead}`);
-        }
+      return new Bluebird((resolve, reject) => {
+        fs.createReadStream(null, {
+          fd: deviceFileDescriptor,
+          autoClose: false,
+          start: position,
+          end: position + length - 1
+        })
+        .on('error', reject)
+        .on('data', (chunk) => {
+          data.push(chunk);
+          progress.tick(chunk);
+        })
+        .on('end', () => {
+          const checksum = hash.calculateChecksum(Buffer.concat(data), bmap.checksumType);
 
-        progress.write(data, () => {
-          emitter.emit('progress', progress.progress());
+          if (checksum !== range.checksum) {
+            invalidChunks.push(range);
+          }
+
+          return resolve();
         });
-
-        const checksum = hash.calculateChecksum(data, bmap.checksumType);
-
-        if (checksum !== range.checksum) {
-          invalidChunks.push(range);
-        }
       });
     }).then(() => {
-      progress.end();
+      progress.stop();
     });
   }).then(() => {
     return emitter.emit('done', invalidChunks);

--- a/lib/offset-transform-stream.js
+++ b/lib/offset-transform-stream.js
@@ -77,8 +77,17 @@ module.exports = (bmap) => {
 
     // Is this a consecutive non-hole block?
     } else if (currentChunk.block === currentBlock - 1) {
-      currentChunk.data.push(chunk);
-      currentChunk.block += 1;
+
+      // Don't push more than 1 MB worth of data at once,
+      // otherwise we might run some time without emitting
+      // progress information.
+      if (currentChunk.data.length >= 1024 * 1024 / bmap.blockSize) {
+        pushCurrentChunk();
+
+      } else {
+        currentChunk.data.push(chunk);
+        currentChunk.block += 1;
+      }
     } else {
       pushCurrentChunk();
     }

--- a/lib/progress.js
+++ b/lib/progress.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+const progressStream = require('progress-stream');
+
+module.exports = class Progress {
+
+  /**
+   * @summary Progress reporter
+   * @name Progress
+   * @class
+   * @public
+   *
+   * @description
+   * This is just a convenient wrapper around `progress-stream`
+   * that allows us to make use of all its goodies without streams.
+   *
+   * @param {Object} options - options
+   * @param {Number} [options.length=0] - total length
+   * @param {Number} [options.time=500] - report time interval
+   * @param {Function} options.callback - callback (state)
+   *
+   * @example
+   * const progress = new Progress({
+   *   length: 4096 * 256,
+   *   callback: (state) => {
+   *     console.log(state);
+   *   }
+   * });
+   */
+  constructor(options) {
+
+    _.defaults(options, {
+      length: 0,
+      time: 500,
+      callback: _.noop
+    });
+
+    // Prevent callback from being called too often
+    this.callback = _.throttle(options.callback, options.time);
+
+    this._progress = progressStream({
+      length: options.length,
+      drain: true
+    });
+  }
+
+  /**
+   * @summary Tick progress
+   * @method
+   * @public
+   *
+   * @param {*} data - data
+   *
+   * @example
+   * const progress = new Progress({
+   *   length: 4096 * 256,
+   *   callback: (state) => {
+   *     console.log(state);
+   *   }
+   * });
+   *
+   * progress.tick(Buffer.alloc(512));
+   */
+  tick(data) {
+    this._progress.write(data, () => {
+      return this.callback(this._progress.progress());
+    });
+  }
+
+  /**
+   * @summary Stop progress
+   * @method
+   * @public
+   *
+   * @example
+   * const progress = new Progress({
+   *   length: 4096 * 256,
+   *   callback: (state) => {
+   *     console.log(state);
+   *   }
+   * });
+   *
+   * progress.stop();
+   */
+  stop() {
+    this._progress.end();
+  }
+
+};


### PR DESCRIPTION
Currently, the progress information gets stuck at a certain point (e.g:
60%) for quite some time and suddenly jumps to say 90%, depending on the
sizes of the ranges.

In order to provide a better user experience, this PR smoothes the
progress information reporting for the writing progress, by making sure
chunks no larger than 1 MB are pushed by the OffsetTransformStream.

Validation suffers the same problem, but we can't tackle it the same way
given there is no transform stream to inject logic into. Instead, we
create readable streams using `start`/`end` ranges on the fly, re-using
the drive file descriptor, and inject logic to emit progress on the
stream's `data` event.

To simplify things, `lib/progress.js` was created, as a way to nicely
encapsulate `progress-stream` for use without streams.

Signed-off-by: Juan Cruz Viotti jviottidc@gmail.com
