### PR TITLE
Fix invalid ranges issues

### DIFF
--- a/example.js
+++ b/example.js
@@ -42,6 +42,7 @@ const flasher = bmapflash.flashImageToFileDescriptor(
 
 flasher.on('error', (error) => {
   console.error(error);
+  fs.closeSync(deviceFileDescriptor);
 });
 
 flasher.on('progress', (state) => {
@@ -55,6 +56,7 @@ flasher.on('done', (error) => {
 
   validator.on('error', (error) => {
     console.error(error);
+    fs.closeSync(deviceFileDescriptor);
   });
 
   validator.on('progress', (state) => {
@@ -68,6 +70,8 @@ flasher.on('done', (error) => {
       console.log('Some blocks were not written correctly:');
       console.log(invalidChunks);
     }
+
+    fs.closeSync(deviceFileDescriptor);
   });
 });
 

--- a/lib/offset-transform-stream.js
+++ b/lib/offset-transform-stream.js
@@ -73,23 +73,22 @@ module.exports = (bmap) => {
 
     // Are we in the final block?
     } else if (currentBlock === bmap.blocksCount - 1) {
+      currentChunk.data.push(chunk);
       pushCurrentChunk();
 
     // Is this a consecutive non-hole block?
     } else if (currentChunk.block === currentBlock - 1) {
+
+      currentChunk.data.push(chunk);
+      currentChunk.block += 1;
 
       // Don't push more than 1 MB worth of data at once,
       // otherwise we might run some time without emitting
       // progress information.
       if (currentChunk.data.length >= 1024 * 1024 / bmap.blockSize) {
         pushCurrentChunk();
-
-      } else {
-        currentChunk.data.push(chunk);
-        currentChunk.block += 1;
       }
-    } else {
-      pushCurrentChunk();
+
     }
 
     currentBlock += 1;


### PR DESCRIPTION
Recently, images being flashed with this module reported certain ranges
always consistently failing validation.

This was caused us accidentally omitting the last chunk from certain ranges
when the collected chunk size exceeded 1 MB, and the very last one.

Signed-off-by: Juan Cruz Viotti jviotti@openmailbox.org
