### PR TITLE
Add `bytesToZeroOutFromTheBeginning` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,24 @@ Documentation
 
 
 * [bmapflash](#module_bmapflash)
-    * [.flashImageToFileDescriptor(imageStream, deviceFileDescriptor, bmapContents)](#module_bmapflash.flashImageToFileDescriptor) ⇒ <code>EventEmitter</code>
+    * [.flashImageToFileDescriptor(imageStream, deviceFileDescriptor, bmapContents, [options])](#module_bmapflash.flashImageToFileDescriptor) ⇒ <code>EventEmitter</code>
     * [.validateFlashedImage(deviceFileDescriptor, bmapContents)](#module_bmapflash.validateFlashedImage) ⇒ <code>EventEmitter</code>
 
 <a name="module_bmapflash.flashImageToFileDescriptor"></a>
 
-### bmapflash.flashImageToFileDescriptor(imageStream, deviceFileDescriptor, bmapContents) ⇒ <code>EventEmitter</code>
+### bmapflash.flashImageToFileDescriptor(imageStream, deviceFileDescriptor, bmapContents, [options]) ⇒ <code>EventEmitter</code>
 **Kind**: static method of <code>[bmapflash](#module_bmapflash)</code>  
 **Summary**: Flash image to file descriptor  
 **Returns**: <code>EventEmitter</code> - event emitter  
 **Access:** public  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| imageStream | <code>ReadableStream</code> | image stream |
-| deviceFileDescriptor | <code>Number</code> | device file descriptor |
-| bmapContents | <code>String</code> | bmap contents |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| imageStream | <code>ReadableStream</code> |  | image stream |
+| deviceFileDescriptor | <code>Number</code> |  | device file descriptor |
+| bmapContents | <code>String</code> |  | bmap contents |
+| [options] | <code>Object</code> | <code>{}</code> | options |
+| [options.bytesToZeroOutFromTheBeginning] | <code>Number</code> | <code>0</code> | bytes to zero out from the beginning |
 
 **Example**  
 ```js

--- a/example.js
+++ b/example.js
@@ -37,7 +37,9 @@ const bmapContents = fs.readFileSync(BMAP_FILE, {
 const flasher = bmapflash.flashImageToFileDescriptor(
   imageStream,
   deviceFileDescriptor,
-  bmapContents
+  bmapContents, {
+    bytesToZeroOutFromTheBeginning: 65536 * 16
+  }
 );
 
 flasher.on('error', (error) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ const OffsetWriteStream = require('./offset-write-stream');
 const offsetTransformStream = require('./offset-transform-stream');
 const bmapFile = require('./bmap-file');
 const hash = require('./hash');
+const utils = require('./utils');
 const Progress = require('./progress');
 
 /**
@@ -47,6 +48,8 @@ const Progress = require('./progress');
  * @param {ReadableStream} imageStream - image stream
  * @param {Number} deviceFileDescriptor - device file descriptor
  * @param {String} bmapContents - bmap contents
+ * @param {Object} [options={}] - options
+ * @param {Number} [options.bytesToZeroOutFromTheBeginning=0] - bytes to zero out from the beginning
  * @returns {EventEmitter} event emitter
  *
  * @example
@@ -80,7 +83,7 @@ const Progress = require('./progress');
  *   });
  * });
  */
-exports.flashImageToFileDescriptor = (imageStream, deviceFileDescriptor, bmapContents) => {
+exports.flashImageToFileDescriptor = (imageStream, deviceFileDescriptor, bmapContents, options = {}) => {
   const emitter = new EventEmitter();
 
   bmapFile.parse(bmapContents).then((bmap) => {
@@ -96,31 +99,36 @@ exports.flashImageToFileDescriptor = (imageStream, deviceFileDescriptor, bmapCon
       }
     });
 
-    return new Bluebird((resolve, reject) => {
-      imageStream
-        .pipe(streamChunker(bmap.blockSize, {
-          flush: true,
-          align: true
-        }))
-        .on('error', reject)
-        .pipe(offsetTransformStream(bmap))
-        .on('error', reject)
-        .pipe(new OffsetWriteStream({
-          write: (data, offset, callback) => {
-            fs.write(deviceFileDescriptor, data, 0, data.length, offset, (error) => {
-              if (error) {
-                return callback(error);
-              }
+    return utils.zeroify(deviceFileDescriptor, {
+      from: 0,
+      count: options.bytesToZeroOutFromTheBeginning || 0
+    }).then(() => {
+      return new Bluebird((resolve, reject) => {
+        imageStream
+          .pipe(streamChunker(bmap.blockSize, {
+            flush: true,
+            align: true
+          }))
+          .on('error', reject)
+          .pipe(offsetTransformStream(bmap))
+          .on('error', reject)
+          .pipe(new OffsetWriteStream({
+            write: (data, offset, callback) => {
+              fs.write(deviceFileDescriptor, data, 0, data.length, offset, (error) => {
+                if (error) {
+                  return callback(error);
+                }
 
-              progress.tick(data);
-              return callback();
-            });
-          }
-        }))
-        .on('error', reject)
-        .on('finish', () => {
-          progress.stop(resolve);
-        });
+                progress.tick(data);
+                return callback();
+              });
+            }
+          }))
+          .on('error', reject)
+          .on('finish', () => {
+            progress.stop(resolve);
+          });
+      });
     });
 
   }).then(() => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Bluebird = require('bluebird');
+const fs = Bluebird.promisifyAll(require('fs'));
+
+/**
+ * @summary Zero out a section of a file descriptor
+ * @function
+ * @public
+ *
+ * @param {Number} fileDescriptor - file descriptor
+ * @param {Object} options = options
+ * @param {Number} options.from - starting point
+ * @param {Number} options.count - number of bytes to zero out
+ * @returns {Promise}
+ *
+ * @example
+ * const fd = fs.openSync('path/to/file', 'rw');
+ *
+ * utils.zeroify(fd, {
+ *   from: 0,
+ *   count: 512 * 1024
+ * }).then(() => {
+ *   console.log(`The first 524288 bytes were zeroed out!`);
+ * });
+ */
+exports.zeroify = (fileDescriptor, options) => {
+
+  // Writing a zero-byte buffer to a common file doesn't
+  // result in any issue (the file is basically not written),
+  // however doing the same on a block device results in `EIO`.
+  if (options.count === 0) {
+    return Bluebird.resolve();
+  }
+
+  const nullBuffer = Buffer.alloc(options.count, 0);
+  return fs.writeAsync(fileDescriptor, nullBuffer, 0, options.count, options.from);
+};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "jsdoc-to-markdown": "^1.1.1",
     "mocha": "^2.4.5",
     "mochainon": "^1.0.0",
-    "streamtest": "^1.2.2"
+    "streamtest": "^1.2.2",
+    "tmp": "0.0.28"
   },
   "dependencies": {
     "bluebird": "^3.4.1",

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const Bluebird = require('bluebird');
+const fs = Bluebird.promisifyAll(require('fs'));
+const tmp = require('tmp');
+const utils = require('../lib/utils');
+
+const readFileContentsAsArray = (file) => {
+  return fs.readFileAsync(file).then((data) => {
+    return JSON.parse(JSON.stringify(data)).data;
+  });
+};
+
+describe('Utils', function() {
+
+  describe('.zeroify()', function() {
+
+    // Create a file containing 32 1 bytes for testing purposes
+    beforeEach(function() {
+      this.file = tmp.fileSync();
+      const buffer = Buffer.alloc(32, 1);
+      fs.writeSync(this.file.fd, buffer, 0, buffer.length, 0);
+    });
+
+    it('should do nothing if count equals zero', function(done) {
+      readFileContentsAsArray(this.file.name).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+
+        return utils.zeroify(this.file.fd, {
+          from: 0,
+          count: 0
+        });
+      }).then(() => {
+        return readFileContentsAsArray(this.file.name);
+      }).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+      }).asCallback(done);
+    });
+
+    it('should be able to zero out a single byte from the beginning', function(done) {
+      readFileContentsAsArray(this.file.name).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+
+        return utils.zeroify(this.file.fd, {
+          from: 0,
+          count: 1
+        });
+      }).then(() => {
+        return readFileContentsAsArray(this.file.name);
+      }).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          0, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+      }).asCallback(done);
+    });
+
+    it('should be able to zero out multiple bytes from the beginning', function(done) {
+      readFileContentsAsArray(this.file.name).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+
+        return utils.zeroify(this.file.fd, {
+          from: 0,
+          count: 5
+        });
+      }).then(() => {
+        return readFileContentsAsArray(this.file.name);
+      }).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          0, 0, 0, 0, 0, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+      }).asCallback(done);
+    });
+
+    it('should be able to zero out a single byte from the middle of the file', function(done) {
+      readFileContentsAsArray(this.file.name).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+
+        return utils.zeroify(this.file.fd, {
+          from: 8,
+          count: 1
+        });
+      }).then(() => {
+        return readFileContentsAsArray(this.file.name);
+      }).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          1, 1, 1, 1, 1, 1, 1, 1,
+          0, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+      }).asCallback(done);
+    });
+
+    it('should be able to zero out multiple bytes from the middle of the file', function(done) {
+      readFileContentsAsArray(this.file.name).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+
+        return utils.zeroify(this.file.fd, {
+          from: 8,
+          count: 3
+        });
+      }).then(() => {
+        return readFileContentsAsArray(this.file.name);
+      }).then((data) => {
+        m.chai.expect(data).to.deep.equal([
+          1, 1, 1, 1, 1, 1, 1, 1,
+          0, 0, 0, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1,
+          1, 1, 1, 1, 1, 1, 1, 1
+        ]);
+      }).asCallback(done);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This option, as the name implies, allows the user to declare that a
certain amount of bytes should be zeroed out before starting the
bmap-assisted write process.

The reason for such a task is that in some cases, `bmap-tools` interpret
zero bytes from the head of the image as holes, causing the bmap flash
program to not explicitly write them, and end up confusing some ROM
boot-loaders.

This is really an issue that should be fixed on the bmap generation
phase, but this is a good enough workaround until the issue is dealt
with property.

See: https://github.com/resin-io/etcher/issues/673
Signed-off-by: Juan Cruz Viotti jviotti@openmailbox.org
